### PR TITLE
Bug in Next-/PrevSiblingByName functions

### DIFF
--- a/UnitTests/Tests/Tests.Neslib.Xml.pas
+++ b/UnitTests/Tests/Tests.Neslib.Xml.pas
@@ -432,7 +432,7 @@ end;
 procedure TTestXmlNode.TestElementByName;
 begin
   var Doc := TXmlDocument.Create;
-  Doc.Parse('<root><node1><node2><node3></node3></node2></node1></root>');
+  Doc.Parse('<root><node1><node2><!--comment--><node3></node3></node2></node1></root>');
 
   var Node := Doc.Root.ElementByName('root')
                       .ElementByName('node1')
@@ -471,7 +471,7 @@ end;
 procedure TTestXmlNode.TestNextSiblingByName;
 begin
   var Doc := TXmlDocument.Create;
-  Doc.Parse('<root><node1/><node2/><node3/><node4/></root>');
+  Doc.Parse('<root><node1/><node2/><node3/><!--comment--><node4/></root>');
 
   var Node := Doc.DocumentElement.FirstChild;
   Assert.AreEqual<XmlString>('node1', Node.Value);
@@ -486,7 +486,7 @@ end;
 procedure TTestXmlNode.TestPrevSiblingByName;
 begin
   var Doc := TXmlDocument.Create;
-  Doc.Parse('<root><node1/><node2/><node3/><node4/></root>');
+  Doc.Parse('<root><node1/><node2/><node3/><!--comment--><node4/></root>');
 
   var Node := Doc.DocumentElement.ElementByName('node4');
   Assert.AreEqual<XmlString>('node4', Node.Value);


### PR DESCRIPTION
This PR exposes a problem in the `Next-/PrevSiblingByName` functions. Both raise an assertion in
`function TXmlNode.GetValueIndex: Integer;` when a comment is "between" the nodes which the `*SiblingByName` try to pass.
`ElementByName` doesn't suffer from this problem.


```
**********************************************************************
*        DUnitX - (c) 2015-2020 Vincent Parrett & Contributors       *
*                                                                    *
*        License - http://www.apache.org/licenses/LICENSE-2.0        *
**********************************************************************

DUnitX - [XmlTests.exe] - Starting Tests.

.........E.E............................................................................................

Tests Found   : 52
Tests Ignored : 0
Tests Passed  : 50
Tests Leaked  : 0
Tests Failed  : 0
Tests Errored : 2

Tests With Errors

  Tests.Neslib.Xml.TTestXmlNode.TestNextSiblingByName
  Message: Assertion fehlgeschlagen (D:\GitHub\Neslib\Neslib.Xml-luebbe\Neslib.Xml.pas, Zeile 1636)

  Tests.Neslib.Xml.TTestXmlNode.TestPrevSiblingByName
  Message: Assertion fehlgeschlagen (D:\GitHub\Neslib\Neslib.Xml-luebbe\Neslib.Xml.pas, Zeile 1636)

```