### PR TITLE
Make Neslib.Xml.IO parse DOCTYPE declarations

### DIFF
--- a/Neslib.Xml.IO.pas
+++ b/Neslib.Xml.IO.pas
@@ -840,18 +840,40 @@ end;
 
 procedure TXmlReader.ParseDocType;
 const
-  CLength = 9;
+  CLength = 8;
 begin
   var P := FCurrent;
-  if StrLIComp(P, '!DOCTYPE ', CLength) <> 0 then
+  if StrLIComp(P, '!DOCTYPE', CLength) <> 0 then
     ParseError(@RS_XML_INVALID_DOCTYPE);
 
   Inc(P, CLength);
+
+  { Next character must either be whitespace or a closing bracket }
+  if (P^ > ' ') and (P^ <> '>') then
+    ParseError(@RS_XML_INVALID_DOCTYPE);
+
+  { Skip control characters (includes spaces, tabs and line breaks)}
+  while (P^ <> #0) and (P^ <= ' ') do
+    Inc(P);
+
   var Start := P;
 
   { Move to end of doctype. }
   while (P^ <> #0) and (P^ <> '>') do
+  begin
+    { Skip inline DTD }
+    if (P^ = '[') then
+    begin
+      while (P^ <> #0) and (P^ <> ']') do
+        Inc(P);
+
+      if (P^ = #0) then
+        ParseError(@RS_XML_UNEXPECTED_EOF);
+      Dec(P);
+    end;
+
     Inc(P);
+  end;
 
   if (P^ = #0) then
     ParseError(@RS_XML_UNEXPECTED_EOF);

--- a/Neslib.Xml.IO.pas
+++ b/Neslib.Xml.IO.pas
@@ -110,6 +110,7 @@ type
     procedure ParseEndElement;
     procedure ParseComment;
     procedure ParseCData;
+    procedure ParseDocType;
     procedure AddAttribute(const ANameStart, ANameEnd, AValueStart,
       AValueEnd: PXmlChar);
   protected
@@ -327,6 +328,7 @@ resourcestring
   RS_XML_CHARACTER_REFERENCE   = 'Invalid character reference in XML data.';
   RS_XML_INVALID_COMMENT       = 'Invalid comment in XML data.';
   RS_XML_INVALID_CDATA         = 'Invalid CDATA in XML data.';
+  RS_XML_INVALID_DOCTYPE       = 'Invalid DOCTYPE in XML data.';
   RS_XML_EQUAL_EXPECTED        = 'Expected "=" after XML attribute name.';
   RS_XML_INVALID_QUOTE         = 'Attribute value must be enclosed in single or double quotes.';
   RS_XML_INVALID_END_ELEMENT   = 'End element is not allowed here.';
@@ -758,6 +760,12 @@ begin
              AState := TXmlReaderState.CData;
              Exit(True);
            end
+           else if (P[1].ToUpper = 'D') then
+           begin
+             ParseDocType;
+             AState := TXmlReaderState.Comment;
+             Exit(True);
+           end
            else
            begin
              ParseComment;
@@ -827,6 +835,28 @@ begin
   if (P^ = #0) then
     ParseError(@RS_XML_UNEXPECTED_EOF);
 
+  FCurrent := P + 1;
+end;
+
+procedure TXmlReader.ParseDocType;
+const
+  CLength = 9;
+begin
+  var P := FCurrent;
+  if StrLIComp(P, '!DOCTYPE ', CLength) <> 0 then
+    ParseError(@RS_XML_INVALID_DOCTYPE);
+
+  Inc(P, CLength);
+  var Start := P;
+
+  { Move to end of doctype. }
+  while (P^ <> #0) and (P^ <> '>') do
+    Inc(P);
+
+  if (P^ = #0) then
+    ParseError(@RS_XML_UNEXPECTED_EOF);
+
+  SetString(FValueString, Start, P - Start);
   FCurrent := P + 1;
 end;
 

--- a/UnitTests/Tests/Tests.Neslib.Xml.IO.pas
+++ b/UnitTests/Tests/Tests.Neslib.Xml.IO.pas
@@ -38,6 +38,7 @@ type
     [Test] procedure TestParseError_ElementNameMismatch;
     [Test] procedure TestIssue9_CommentsAtStart;
     [Test] procedure TestIssue11;
+    [Test] procedure TestDoctype;
   end;
 
 type
@@ -241,6 +242,35 @@ begin
     else
       Assert.Fail('EXmlParserError expected');
   end;
+end;
+
+procedure TTestXmlReader.TestDoctype;
+const
+  CDocType = 'bookinfo SYSTEM "../../tools/dtd/dblite.dtd"';
+  CXml = '<?xml version="1.0" encoding="utf-8"?>'+ sLineBreak +
+    '<!DOCTYPE ' + CDocType + '>' + sLineBreak +
+    '<bookinfo>'+ sLineBreak +
+    '  <pubdate>'+ sLineBreak +
+    '    <?dbtimestamp format="d. B Y"?>'+ sLineBreak +
+    '  </pubdate>'+ sLineBreak +
+    '</bookinfo>';
+begin
+  var Doc := TXmlDocument.Create;
+  Doc.Parse(CXml);
+  {   Check DOCTYPE value }
+  var Root := Doc.Root;
+  var Node := Root.FirstChild;
+  Assert.IsTrue(Node.Parent = Root);
+  Assert.AreEqual<TXmlNodeType>(TXmlNodeType.Comment, Node.NodeType);
+  Assert.AreEqual<XmlString>(CDocType, Node.Value);
+  Assert.IsTrue(Node.FirstAttribute = nil);
+  Assert.IsTrue(Node.FirstChild = nil);
+  {   Check bookinfo node }
+  Node := Node.NextSibling;
+  Assert.AreEqual<TXmlNodeType>(TXmlNodeType.Element, Node.NodeType);
+  Assert.AreEqual<XmlString>('bookinfo', Node.Value);
+  Assert.IsTrue(Node.FirstAttribute = nil);
+  Assert.IsFalse(Node.FirstChild = nil);
 end;
 
 procedure TTestXmlReader.TestIssue11;

--- a/UnitTests/Tests/Tests.Neslib.Xml.IO.pas
+++ b/UnitTests/Tests/Tests.Neslib.Xml.IO.pas
@@ -38,7 +38,23 @@ type
     [Test] procedure TestParseError_ElementNameMismatch;
     [Test] procedure TestIssue9_CommentsAtStart;
     [Test] procedure TestIssue11;
-    [Test] procedure TestDoctype;
+
+    [Test]
+    [TestCase('Empty', '')]
+    [TestCase('Invalid', 'X,,,Invalid DOCTYPE in XML data.,1,39')]
+    [TestCase('Valid DTD', ' ,bookinfo SYSTEM "../../tools/dtd/dblite.dtd"')]
+    [TestCase('Inline valid definition', ' ,element [DEFINITION]')]
+    [TestCase('Inline missing definition close', ' ,element [DEFINITION,,Unexpected end of XML data.,1,39')]
+
+    // Invalid XML. The parser skips everything between
+    // the first closing ']' and the next closing '>'
+    [TestCase('Inline double definition close', ' ,element [DEFINITION]],')]
+    [TestCase('Inline double definition close junk', ' ,element [DEFINITION]###]!!!,')]
+
+    // Invalid XML. The parser skips the double closing '>>' bracket
+    // and returns a text node, which is not correct and which is why this testis disabled
+    //[TestCase('Inline double doctype close', ' ,element [DEFINITION],>')]
+    procedure TestDoctype(const APrefix, AContent, ASuffix, AErrorMsg: String; const ALine, AColumn: Integer);
   end;
 
 type
@@ -57,6 +73,9 @@ type
   end;
 
 implementation
+
+uses
+  System.SysUtils;
 
 { TTestXmlReader }
 
@@ -244,33 +263,48 @@ begin
   end;
 end;
 
-procedure TTestXmlReader.TestDoctype;
+procedure TTestXmlReader.TestDoctype(
+  const APrefix, AContent, ASuffix, AErrorMsg: String;
+  const ALine, AColumn: Integer);
 const
-  CDocType = 'bookinfo SYSTEM "../../tools/dtd/dblite.dtd"';
-  CXml = '<?xml version="1.0" encoding="utf-8"?>'+ sLineBreak +
-    '<!DOCTYPE ' + CDocType + '>' + sLineBreak +
-    '<bookinfo>'+ sLineBreak +
-    '  <pubdate>'+ sLineBreak +
-    '    <?dbtimestamp format="d. B Y"?>'+ sLineBreak +
-    '  </pubdate>'+ sLineBreak +
+  CXml = '<?xml version="1.0" encoding="utf-8"?>' + sLineBreak +
+    '<!DOCTYPE%s%s%s>' + sLineBreak +
+    '<bookinfo>' + sLineBreak +
+    '  <pubdate>' + sLineBreak +
+    '    <?dbtimestamp format="d. B Y"?>' + sLineBreak +
+    '  </pubdate>' + sLineBreak +
     '</bookinfo>';
 begin
   var Doc := TXmlDocument.Create;
-  Doc.Parse(CXml);
-  {   Check DOCTYPE value }
-  var Root := Doc.Root;
-  var Node := Root.FirstChild;
-  Assert.IsTrue(Node.Parent = Root);
-  Assert.AreEqual<TXmlNodeType>(TXmlNodeType.Comment, Node.NodeType);
-  Assert.AreEqual<XmlString>(CDocType, Node.Value);
-  Assert.IsTrue(Node.FirstAttribute = nil);
-  Assert.IsTrue(Node.FirstChild = nil);
-  {   Check bookinfo node }
-  Node := Node.NextSibling;
-  Assert.AreEqual<TXmlNodeType>(TXmlNodeType.Element, Node.NodeType);
-  Assert.AreEqual<XmlString>('bookinfo', Node.Value);
-  Assert.IsTrue(Node.FirstAttribute = nil);
-  Assert.IsFalse(Node.FirstChild = nil);
+  var Xml := Format(CXml, [APrefix, AContent, ASuffix]);
+
+  try
+    Doc.Parse(Xml);
+
+    {   Check DOCTYPE value }
+    var Root := Doc.Root;
+    var Node := Root.FirstChild;
+    Assert.IsTrue(Node.Parent = Root);
+    Assert.AreEqual<TXmlNodeType>(TXmlNodeType.Comment, Node.NodeType);
+    Assert.AreEqual<XmlString>(AContent, Node.Value);
+    Assert.IsTrue(Node.FirstAttribute = nil);
+    Assert.IsTrue(Node.FirstChild = nil);
+    {   Check bookinfo node }
+    Node := Node.NextSibling;
+    Assert.AreEqual<TXmlNodeType>(TXmlNodeType.Element, Node.NodeType);
+    Assert.AreEqual<XmlString>('bookinfo', Node.Value);
+    Assert.IsTrue(Node.FirstAttribute = nil);
+    Assert.IsFalse(Node.FirstChild = nil);
+  except
+    on E: EXmlParserError do
+    begin
+      Assert.AreEqual(AErrorMsg, E.Message);
+      Assert.AreEqual(ALine, E.LineNumber);
+      Assert.AreEqual(AColumn, E.ColumnNumber);
+    end
+    else
+      Assert.Fail('EXmlParserError expected');
+  end;
 end;
 
 procedure TTestXmlReader.TestIssue11;

--- a/UnitTests/Tests/Tests.Neslib.Xml.IO.pas
+++ b/UnitTests/Tests/Tests.Neslib.Xml.IO.pas
@@ -275,12 +275,27 @@ const
     '  </pubdate>' + sLineBreak +
     '</bookinfo>';
 begin
+  var Success := false;
   var Doc := TXmlDocument.Create;
   var Xml := Format(CXml, [APrefix, AContent, ASuffix]);
 
   try
     Doc.Parse(Xml);
+    Success := true;
 
+  except
+    on E: EXmlParserError do
+    begin
+      Assert.AreEqual(AErrorMsg, E.Message);
+      Assert.AreEqual(ALine, E.LineNumber);
+      Assert.AreEqual(AColumn, E.ColumnNumber);
+    end
+    else
+      Assert.Fail('EXmlParserError expected');
+  end;
+
+  if Success then
+  begin
     {   Check DOCTYPE value }
     var Root := Doc.Root;
     var Node := Root.FirstChild;
@@ -295,15 +310,6 @@ begin
     Assert.AreEqual<XmlString>('bookinfo', Node.Value);
     Assert.IsTrue(Node.FirstAttribute = nil);
     Assert.IsFalse(Node.FirstChild = nil);
-  except
-    on E: EXmlParserError do
-    begin
-      Assert.AreEqual(AErrorMsg, E.Message);
-      Assert.AreEqual(ALine, E.LineNumber);
-      Assert.AreEqual(AColumn, E.ColumnNumber);
-    end
-    else
-      Assert.Fail('EXmlParserError expected');
   end;
 end;
 

--- a/UnitTests/XmlTests.dpr
+++ b/UnitTests/XmlTests.dpr
@@ -1,13 +1,18 @@
 program XmlTests;
 
 {$IFDEF MSWINDOWS}
+  {$STRONGLINKTYPES ON}
+  {$IFNDEF TESTINSIGHT}
   {$APPTYPE CONSOLE}
+  {$ENDIF}
   {$WARN SYMBOL_PLATFORM OFF}
 {$ENDIF}
 
 uses
   System.SysUtils,
-  {$IF Defined(MACOS) or Defined(ANDROID)}
+  {$IF Defined(TESTINSIGHT)}
+  TestInsight.DUnitX,
+  {$ELSE IF Defined(MACOS) or Defined(ANDROID)}
   FMX.Forms,
   DUnitX.Loggers.MobileGUI,
   {$ELSE}
@@ -24,6 +29,9 @@ uses
 {$R *.res}
 
 begin
+{$IF Defined(TESTINSIGHT)}
+  TestInsight.DUnitX.RunRegisteredTests;
+{$ELSE}
   TDUnitX.CheckCommandLine;
 
   {$IF Defined(MACOS) or Defined(ANDROID)}
@@ -53,4 +61,5 @@ begin
       Writeln(E.ClassName, ': ', E.Message);
   end;
   {$ENDIF}
+{$ENDIF}
 end.


### PR DESCRIPTION
This PR contains a fix for #15 as well as support for TestInsight as an additional UI for unit tests.

I didn't introduce an exta TXmlReaderStatefor DOCTYPE, but reused `Comment`, since the comment in Neslib.Xml.IO says 
' ... or a DTD definition'
```
    { The reader is positioned at a comment (eg. <!-- Comment -->) or a DTD
      definition. }
    Comment,
```