### PR TITLE
Add a case insensitive option to the ElementByAttribute methods.

### DIFF
--- a/Neslib.Xml.pas
+++ b/Neslib.Xml.pas
@@ -320,7 +320,7 @@ type
         The first child element with an attribute with the given name and value,
         or nil if there is none. }
     function ElementByAttribute(const AAttributeName,
-      AAttributeValue: XmlString): TXmlNode; overload;
+      AAttributeValue: XmlString; AIgnoreCase: Boolean = false): TXmlNode; overload;
 
     { Returns the first child element of a given name, and with an attribute
       with a given name and value.
@@ -334,7 +334,7 @@ type
         The first child element with the given name that has an attribute with
         the given atrribute name and value, or nil if there is none. }
     function ElementByAttribute(const AElementName, AAttributeName,
-      AAttributeValue: XmlString): TXmlNode; overload;
+      AAttributeValue: XmlString; AIgnoreCase: Boolean = false): TXmlNode; overload;
 
     { Returns the next sibling element with a given name.
 
@@ -1274,7 +1274,8 @@ begin
 end;
 
 function TXmlNode.ElementByAttribute(const AAttributeName,
-  AAttributeValue: XmlString): TXmlNode;
+  AAttributeValue: XmlString;
+  AIgnoreCase: Boolean): TXmlNode;
 begin
   Result.FNode := nil;
   if (FNode = nil) or (GetNodeType <> TXmlNodeType.Element) then
@@ -1292,8 +1293,11 @@ begin
     var Attr := Result.FirstAttribute;
     while (Attr <> nil) do
     begin
-      if (Attr.GetNameIndex = NameIndex) and (Attr.Value = AAttributeValue) then
-        Exit;
+      if (Attr.GetNameIndex = NameIndex) then
+        if AIgnoreCase and SameText(Attr.Value, AAttributeValue) then
+          Exit
+        else if SameStr(Attr.Value, AAttributeValue) then
+          Exit;
 
       Attr := Attr.Next;
     end;
@@ -1302,7 +1306,8 @@ begin
 end;
 
 function TXmlNode.ElementByAttribute(const AElementName, AAttributeName,
-  AAttributeValue: XmlString): TXmlNode;
+  AAttributeValue: XmlString;
+  AIgnoreCase: Boolean): TXmlNode;
 begin
   Result.FNode := nil;
   if (FNode = nil) or (GetNodeType <> TXmlNodeType.Element) then
@@ -1327,7 +1332,9 @@ begin
       var Attr := Result.FirstAttribute;
       while (Attr <> nil) do
       begin
-        if (Attr.GetNameIndex = AttrNameIndex) and (Attr.Value = AAttributeValue) then
+        if AIgnoreCase and SameText(Attr.Value, AAttributeValue) then
+          Exit
+        else if SameStr(Attr.Value, AAttributeValue) then
           Exit;
 
         Attr := Attr.Next;

--- a/UnitTests/Tests/Tests.Neslib.Xml.pas
+++ b/UnitTests/Tests/Tests.Neslib.Xml.pas
@@ -406,6 +406,12 @@ begin
 
   Node := Doc.DocumentElement.ElementByAttribute('attr', 'D');
   Assert.AreEqual<XmlString>('', Node.Value);
+
+  Node := Doc.DocumentElement.ElementByAttribute('attr', 'a');
+  Assert.AreEqual<XmlString>('', Node.Value);
+
+  Node := Doc.DocumentElement.ElementByAttribute('attr', 'a', true);
+  Assert.AreEqual<XmlString>('node1', Node.Value);
 end;
 
 procedure TTestXmlNode.TestElementByAttributeAndElement;
@@ -427,6 +433,12 @@ begin
 
   Node := Doc.DocumentElement.ElementByAttribute('foo', 'attr', 'C');
   Assert.AreEqual(0, Node.AttributeByName('id').ToInteger);
+
+  Node := Doc.DocumentElement.ElementByAttribute('node', 'attr', 'a');
+  Assert.AreEqual<XmlString>('', Node.Value);
+
+  Node := Doc.DocumentElement.ElementByAttribute('node', 'attr', 'a', true);
+  Assert.AreEqual(1, Node.AttributeByName('id').ToInteger);
 end;
 
 procedure TTestXmlNode.TestElementByName;


### PR DESCRIPTION
This allows to search for attribute *values* ignoring case. Search by element and attribute names is still case sensitive.
Reason: still finding data, when someone has made a capitalization error when entering it.